### PR TITLE
Use `node:fs` version of `realpath`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import fsSync from 'node:fs'
 import path from 'node:path'
 import {
   isDepIncluded,
@@ -207,7 +208,8 @@ export async function findDepPkgJsonPath(dep, parent) {
     const pkg = path.join(root, 'node_modules', dep, 'package.json')
     try {
       await fs.access(pkg)
-      return await fs.realpath(pkg)
+	  // use 'node:fs' version to match 'vite:resolve'
+      return fsSync.realpathSync(pkg)
     } catch {}
     const nextRoot = path.dirname(root)
     if (nextRoot === root) break

--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,8 @@ export async function findDepPkgJsonPath(dep, parent) {
     const pkg = path.join(root, 'node_modules', dep, 'package.json')
     try {
       await fs.access(pkg)
-	  // use 'node:fs' version to match 'vite:resolve'
+      // use 'node:fs' version to match 'vite:resolve' and avoid realpath.native quirk
+      // https://github.com/sveltejs/vite-plugin-svelte/issues/525#issuecomment-1355551264
       return fsSync.realpathSync(pkg)
     } catch {}
     const nextRoot = path.dirname(root)


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/sveltejs/vite-plugin-svelte/issues/525), the `node:fs/promises` version of `realpath` has different behavior from the `node:fs` version used by `vite:resolve`.