### PR TITLE
Allow Vite 6 beta peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test": "uvu tests \".*\\.test\\.js\""
 	},
 	"peerDependencies": {
-		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0"
 	},
 	"peerDependenciesMeta": {
 		"vite": {


### PR DESCRIPTION
Currently there's a peer dep warning in the Astro beta (which uses the Vite beta) because `vitefu` hasn't extend the range yet. Probably fine to extend it temporarily now.