### PR TITLE
Remove -beta.2 from vite 6 peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test": "uvu tests \".*\\.test\\.js\""
 	},
 	"peerDependencies": {
-		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0-beta.0"
+		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
 	},
 	"peerDependenciesMeta": {
 		"vite": {


### PR DESCRIPTION
Now that the vite 6 stable is out the -beta in peerDeps isn't necessary anymore

```sh
➜ pnpm i -D vite@latest
Already up to date
Progress: resolved 529, reused 478, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ vitefu 0.2.5
  └── ✕ unmet peer vite@"^3.0.0 || ^4.0.0 || ^5.0.0": found 6.0.0

Done in 800ms
```

