### PR TITLE
support package.json5 and package.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,9 @@
 	"workspaces": [
 		"tests/deps/*",
 		"tests/projects/*"
-	]
+	],
+	"dependencies": {
+		"json5": "^2.2.3",
+		"yaml": "^2.6.1"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
+      yaml:
+        specifier: ^2.6.1
+        version: 2.6.1
     devDependencies:
       '@types/node':
         specifier: ^14.18.63
@@ -76,6 +83,31 @@ importers:
   tests/deps/should-no-external-lib: {}
 
   tests/projects/basic:
+    dependencies:
+      '@vitefu/dep-esm-js-lib':
+        specifier: file:../../deps/esm-js-lib
+        version: file:tests/deps/esm-js-lib
+      '@vitefu/dep-framework':
+        specifier: file:../../deps/framework
+        version: file:tests/deps/framework
+      '@vitefu/dep-full-direct-framework-lib':
+        specifier: file:../../deps/full-direct-framework-lib
+        version: file:tests/deps/full-direct-framework-lib(@vitefu/dep-framework@file:tests/deps/framework)
+      '@vitefu/dep-full-framework-lib':
+        specifier: file:../../deps/full-framework-lib
+        version: file:tests/deps/full-framework-lib(@vitefu/dep-framework@file:tests/deps/framework)
+      '@vitefu/dep-proxy-framework-lib':
+        specifier: file:../../deps/proxy-framework-lib
+        version: file:tests/deps/proxy-framework-lib(@vitefu/dep-framework@file:tests/deps/framework)
+      '@vitefu/dep-semi-framework-lib':
+        specifier: file:../../deps/semi-framework-lib
+        version: file:tests/deps/semi-framework-lib
+    devDependencies:
+      uvu:
+        specifier: ^0.5.6
+        version: 0.5.6
+
+  tests/projects/pnpmer:
     dependencies:
       '@vitefu/dep-esm-js-lib':
         specifier: file:../../deps/esm-js-lib
@@ -308,6 +340,11 @@ packages:
     resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
     engines: {node: '>= 0.4'}
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -381,6 +418,11 @@ packages:
         optional: true
       terser:
         optional: true
+
+  yaml@2.6.1:
+    resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
+    engines: {node: '>= 14'}
+    hasBin: true
 
 snapshots:
 
@@ -533,6 +575,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  json5@2.2.3: {}
+
   kleur@4.1.5: {}
 
   mri@1.2.0: {}
@@ -583,3 +627,5 @@ snapshots:
     optionalDependencies:
       '@types/node': 14.18.63
       fsevents: 2.3.3
+
+  yaml@2.6.1: {}

--- a/tests/projects/pnpmer/basic.test.js
+++ b/tests/projects/pnpmer/basic.test.js
@@ -1,0 +1,124 @@
+import { fileURLToPath } from 'node:url'
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+import { crawlFrameworkPkgs } from '../../../src/index.js'
+
+const root = fileURLToPath(new URL('./', import.meta.url))
+
+test('crawlFrameworkPkgs (dev)', async () => {
+  const result = await callCrawlFrameworkPkgs(false)
+  assert.equal(result, {
+    optimizeDeps: {
+      include: [
+        '@vitefu/dep-full-direct-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-full-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-full-framework-lib > @vitefu/dep-implicit-entry-cjs-lib',
+        '@vitefu/dep-proxy-framework-lib > @vitefu/dep-full-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-proxy-framework-lib > @vitefu/dep-full-framework-lib > @vitefu/dep-implicit-entry-cjs-lib'
+      ],
+      exclude: [
+        '@vitefu/dep-full-direct-framework-lib',
+        '@vitefu/dep-full-framework-lib',
+        '@vitefu/dep-proxy-framework-lib'
+      ]
+    },
+    ssr: {
+      noExternal: [
+        '@vitefu/dep-full-direct-framework-lib',
+        '@vitefu/dep-full-framework-lib',
+        '@vitefu/dep-proxy-framework-lib',
+        '@vitefu/dep-semi-framework-lib'
+      ],
+      external: [
+        '@vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-framework',
+        '@vitefu/dep-implicit-entry-cjs-lib',
+        '@vitefu/dep-no-deep-optimize-lib',
+        '@vitefu/dep-no-entry-lib'
+      ]
+    }
+  })
+})
+
+test('crawlFrameworkPkgs (build)', async () => {
+  const result = await callCrawlFrameworkPkgs(true)
+  assert.equal(result, {
+    optimizeDeps: {
+      include: [
+        '@vitefu/dep-full-direct-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-full-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-full-framework-lib > @vitefu/dep-implicit-entry-cjs-lib',
+        '@vitefu/dep-proxy-framework-lib > @vitefu/dep-full-framework-lib > @vitefu/dep-cjs-js-lib',
+        '@vitefu/dep-proxy-framework-lib > @vitefu/dep-full-framework-lib > @vitefu/dep-implicit-entry-cjs-lib'
+      ],
+      exclude: [
+        '@vitefu/dep-full-direct-framework-lib',
+        '@vitefu/dep-full-framework-lib',
+        '@vitefu/dep-proxy-framework-lib'
+      ]
+    },
+    ssr: {
+      noExternal: [
+        '@vitefu/dep-full-direct-framework-lib',
+        '@vitefu/dep-full-framework-lib',
+        '@vitefu/dep-proxy-framework-lib',
+        '@vitefu/dep-semi-framework-lib'
+      ],
+      external: []
+    }
+  })
+})
+
+test.run()
+
+/**
+ * @param {boolean} isBuild
+ */
+async function callCrawlFrameworkPkgs(isBuild) {
+  const result = await crawlFrameworkPkgs({
+    root,
+    isBuild,
+    viteUserConfig: {
+      optimizeDeps: {
+        exclude: ['@vitefu/dep-no-deep-optimize-lib']
+      },
+      ssr: {
+        noExternal: [/@vitefu\/dep-should-no-external-lib/]
+      }
+    },
+    isFrameworkPkgByJson: (pkgJson) => {
+      return exportsHasFrameworkField(pkgJson.exports || {})
+    },
+    isSemiFrameworkPkgByJson: (pkgJson) => {
+      return !!(
+        pkgJson.dependencies?.['@vitefu/dep-framework'] ||
+        pkgJson.peerDependencies?.['@vitefu/dep-framework']
+      )
+    }
+  })
+  // sort for deep equal comparison
+  result.optimizeDeps.include.sort()
+  result.optimizeDeps.exclude.sort()
+  result.ssr.noExternal.sort()
+  result.ssr.external.sort()
+  return result
+}
+
+/**
+ * @param {Record<string, any>} exports
+ */
+function exportsHasFrameworkField(exports) {
+  for (const [key, value] of Object.entries(exports)) {
+    if (key === 'framework') {
+      return true
+    } else if (
+      typeof value === 'object' &&
+      value != null &&
+      exportsHasFrameworkField(value)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+

--- a/tests/projects/pnpmer/package.json5
+++ b/tests/projects/pnpmer/package.json5
@@ -1,0 +1,18 @@
+{
+	// tests support for package.json5 in pnpm projects
+	name: "@vitefu/project-pnpmer",
+	version: "0.0.1",
+	private: true,
+	type: 'module',
+	dependencies: {
+    "@vitefu/dep-esm-js-lib": "file:../../deps/esm-js-lib",
+    "@vitefu/dep-framework": "file:../../deps/framework",
+    "@vitefu/dep-full-direct-framework-lib": "file:../../deps/full-direct-framework-lib",
+    "@vitefu/dep-full-framework-lib": "file:../../deps/full-framework-lib",
+    "@vitefu/dep-proxy-framework-lib": "file:../../deps/proxy-framework-lib",
+    "@vitefu/dep-semi-framework-lib": "file:../../deps/semi-framework-lib"
+	},
+  devDependencies: {
+    uvu: "^0.5.6"
+  }
+}


### PR DESCRIPTION
pnpm supports using `package.json5` and `package.yaml` in lieu of `package.json`, which are expected to be compatible with `package.json` files except for the formatting.

this commit detects `package.json5` or `package.yaml` usage, deserializing the file as appropriate.

in order to deserialize the formats appropriately, i've added 2 dependencies: `json5` and `yaml`. I was hesitant to do so, but didn't feel like hand-rolling a parser for this, and those dependencies themselves have no dependencies

i've also added a test that's verbatim the current `basic` test, except using a valid json5 (and invalid json) file to ensure that there are no unexpected behavioral changes when parsing using an alternative format.