### PR TITLE
Handle `ssr.external: true` for `isDepExternaled`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,11 @@ export async function crawlFrameworkPkgs(options) {
     }
     // remove noExternals that are explicitly externalized
     const _ssrExternal = options.viteUserConfig?.ssr?.external
-    if (_ssrExternal) {
+    // @ts-expect-error can be true in Vite 6
+    // We want to skip this if it's true, because they're not exactly
+    // explicitly externalized. It just means that they also want to
+    // externalized linked dependencies by default.
+    if (_ssrExternal && _ssrExternal !== true) {
       ssrNoExternal = ssrNoExternal.filter(
         (dep) => !isDepExternaled(dep, _ssrExternal)
       )

--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,7 @@ export async function crawlFrameworkPkgs(options) {
     }
     // remove noExternals that are explicitly externalized
     const _ssrExternal = options.viteUserConfig?.ssr?.external
-    // @ts-expect-error can be true in Vite 6
-    // We want to skip this if it's true, because they're not exactly
-    // explicitly externalized. It just means that they also want to
-    // externalized linked dependencies by default.
-    if (_ssrExternal && _ssrExternal !== true) {
+    if (_ssrExternal) {
       ssrNoExternal = ssrNoExternal.filter(
         (dep) => !isDepExternaled(dep, _ssrExternal)
       )

--- a/src/sync.cjs
+++ b/src/sync.cjs
@@ -62,5 +62,5 @@ module.exports = {
   isDepIncluded,
   isDepExcluded,
   isDepNoExternaled,
-  isDepExternaled,
+  isDepExternaled
 }

--- a/src/sync.cjs
+++ b/src/sync.cjs
@@ -24,7 +24,12 @@ function isDepNoExternaled(dep, ssrNoExternal) {
 
 /** @type {import('./index.d.ts').isDepExternaled} */
 function isDepExternaled(dep, ssrExternal) {
-  return ssrExternal.includes(dep)
+  // @ts-expect-error can be true in Vite 6
+  if (ssrExternal === true) {
+    return true
+  } else {
+    return ssrExternal.includes(dep)
+  }
 }
 
 /**

--- a/src/sync.cjs
+++ b/src/sync.cjs
@@ -24,9 +24,13 @@ function isDepNoExternaled(dep, ssrNoExternal) {
 
 /** @type {import('./index.d.ts').isDepExternaled} */
 function isDepExternaled(dep, ssrExternal) {
+  // If `ssrExternal` is `true`, it just means that all linked
+  // dependencies should also be externalized by default. It doesn't
+  // mean that a dependency is being explicitly externalized. So we
+  // return `false` in this case.
   // @ts-expect-error can be true in Vite 6
   if (ssrExternal === true) {
-    return true
+    return false
   } else {
     return ssrExternal.includes(dep)
   }
@@ -58,5 +62,5 @@ module.exports = {
   isDepIncluded,
   isDepExcluded,
   isDepNoExternaled,
-  isDepExternaled
+  isDepExternaled,
 }


### PR DESCRIPTION
fix https://github.com/svitejs/vitefu/issues/18

`ssr.external: true` is a tricky one and involves a little different behaviour, I've commented why I did so.