### PR TITLE
feat: extend peer dependency range to include vite7

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test": "uvu tests \".*\\.test\\.js\""
 	},
 	"peerDependencies": {
-		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+		"vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
 	},
 	"peerDependenciesMeta": {
 		"vite": {


### PR DESCRIPTION
the version selector includes beta, we can drop that later if needed but as it also matches 7.x.y its cosmetic