### PR TITLE
fix: ensure isPrivateWorkspacePackage works on windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -306,8 +306,10 @@ async function readJson(findDepPkgJsonPath) {
  * @returns {boolean}
  */
 function isPrivateWorkspacePackage(pkgJsonPath,pkgJson,workspaceRoot = undefined) {
-  return !!workspaceRoot
-      && pkgJson.private
-      && pkgJsonPath.startsWith(workspaceRoot)
-      && !pkgJsonPath.match(/[/\\]node_modules[/\\]/)
+  return !!(
+    workspaceRoot &&
+    pkgJson.private &&
+    !pkgJsonPath.match(/[/\\]node_modules[/\\]/) &&
+    !path.relative(workspaceRoot,pkgJsonPath).startsWith('..')
+  )
 }

--- a/tests/projects/workspace/workspace.test.js
+++ b/tests/projects/workspace/workspace.test.js
@@ -3,7 +3,9 @@ import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 import {crawlFrameworkPkgs} from '../../../src/index.js'
 
-const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url)).replace(/\/$/,'')
+const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url))
+    .replace(/\\/g,'/') // vite's seachForWorkspaceRoot returns slashified string on windows do that here too
+    .replace(/\/$/,'')
 const root = fileURLToPath(new URL('./packages/workspace-app', import.meta.url)).replace(/\/$/,'')
 
 test('crawlFrameworkPkgs (dev)', async () => {


### PR DESCRIPTION
use path.relative to determine pkgJsonPath inside workspaceRoot in a platform agnostic way